### PR TITLE
Move IE classes from body to html tag

### DIFF
--- a/header.php
+++ b/header.php
@@ -5,7 +5,10 @@
  */
 ?>
 <!doctype html>
-<html lang="en" class="no-js">
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
 
@@ -51,11 +54,7 @@
 
 <!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
 
-<!--[if lt IE 7 ]> <body <?php body_class('ie6'); ?>> <![endif]-->
-<!--[if IE 7 ]>    <body <?php body_class('ie7'); ?>> <![endif]-->
-<!--[if IE 8 ]>    <body <?php body_class('ie8'); ?>> <![endif]-->
-<!--[if IE 9 ]>    <body <?php body_class('ie9'); ?>> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <body <?php body_class('ie6'); ?>> <!--<![endif]-->
+<body <?php body_class(); ?>>
 
   <div id="container">
     <header role="banner">

--- a/header.php
+++ b/header.php
@@ -12,9 +12,6 @@
 <head>
   <meta charset="utf-8">
 
-  <!-- www.phpied.com/conditional-comments-block-downloads/ -->
-  <!--[if IE]><![endif]-->
-
   <!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame
        Remove this if you use the .htaccess -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -38,9 +35,6 @@
 
   <!-- CSS : implied media="all" -->
   <?php versioned_stylesheet($GLOBALS["TEMPLATE_RELATIVE_URL"]."html5-boilerplate/css/style.css") ?>
-
-  <!-- For the less-enabled mobile browsers like Opera Mini -->
-  <?php versioned_stylesheet($GLOBALS["TEMPLATE_RELATIVE_URL"]."html5-boilerplate/css/handheld.css", 'media="handheld"') ?>
 
   <!-- All JavaScript at the bottom, except for Modernizr which enables HTML5 elements & feature detects -->
   <?php versioned_javascript($GLOBALS["TEMPLATE_RELATIVE_URL"]."html5-boilerplate/js/modernizr-1.5.min.js") ?>


### PR DESCRIPTION
Hi Zencoder

This allows much better usage of the ie classes in conjunction with wordpress body classes.

Also I removed the handheld stylesheet as it's not in the current boilerplate and I've never used it...

Steve
